### PR TITLE
Version 1.9 Suggestion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Vdoo Analysis is a Jenkins plugin that enables Jenkins users to test their images using Vdoo automated security analysis platform as a part of their CI/CD process.
 
+## Build
+```
+mvn install
+```
 ## Configuration
 
 1. To configure your Jenkins project, first add “Vdoo Analysis Plugin” as a build step to your build.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>vdoo-vision</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>1.0</revision>
@@ -56,7 +56,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>vdoo-vision-1.1</tag>
+        <tag>vdoo-vision-1.9.1</tag>
     </scm>
 
     <repositories>

--- a/src/main/java/com/vdoo/vision/plugin/ScannerBuilder.java
+++ b/src/main/java/com/vdoo/vision/plugin/ScannerBuilder.java
@@ -29,6 +29,7 @@ public class ScannerBuilder extends Builder implements SimpleBuildStep {
     private String maxMaliciousFiles;
     private Integer productId;
     private String firmwareLocation;
+    private String firmwareVersion;
     private Boolean waitForResults;
 
     private String baseApi;
@@ -66,6 +67,10 @@ public class ScannerBuilder extends Builder implements SimpleBuildStep {
 
     public String getFirmwareLocation() {
         return firmwareLocation;
+    }
+
+    public String getFirmwareVersion() {
+        return firmwareVersion;
     }
 
     public String getBaseApi() {
@@ -122,6 +127,11 @@ public class ScannerBuilder extends Builder implements SimpleBuildStep {
     }
 
     @DataBoundSetter
+    public void setFirmwareVersion(String firmwareVersion) {
+        this.firmwareVersion = firmwareVersion;
+    }
+
+    @DataBoundSetter
     public void setVdooToken(Secret vdooToken) {
         this.vdooToken = vdooToken;
     }
@@ -137,6 +147,7 @@ public class ScannerBuilder extends Builder implements SimpleBuildStep {
                 maxMaliciousFiles,
                 productId,
                 firmwareLocation,
+                firmwareVersion,
                 this.baseApi,
                 this.waitForResults,
                 listener,

--- a/src/main/resources/com/vdoo/vision/plugin/ScannerBuilder/config.jelly
+++ b/src/main/resources/com/vdoo/vision/plugin/ScannerBuilder/config.jelly
@@ -44,6 +44,9 @@
         <f:textbox field="firmwareLocation" />
     </f:entry>
 
+    <f:entry title="${%FirmwareVersion}" field="firmwareVersion" description="${%FirmwareVersionDescr}">
+        <f:textbox field="firmwareVersion" />
+    </f:entry>
 
     <f:advanced>
         <f:entry title="${%BaseApi}" field="baseApi" description="${%BaseApiDescr}">

--- a/src/main/resources/com/vdoo/vision/plugin/ScannerBuilder/config.properties
+++ b/src/main/resources/com/vdoo/vision/plugin/ScannerBuilder/config.properties
@@ -25,5 +25,8 @@ ProductIdDescr=Artifact ID to which the uploaded image is added.
 FirmwareLocation=Image Location
 FirmwareLocationDescr=Location of the file to upload and analyse.
 
+FirmwareVersion=Image version
+FirmwareVersionDescr=Version of the file to upload and analyse.
+
 WaitForResults=Wait for Analysis Results
 WaitForResultsDescr=Should the plugin wait for the analysis results, failing the build if "Threat Level Fail Threshold" is reached, or just upload the image. The results will appear in Vdoo Vision regardless of this flag's value.


### PR DESCRIPTION
Hi,

While working with the latest plugin version (1.8) I have encountered few issues.
So decided to solve them in my fork and unite them under the title of "v1.9":
- Added the `artifactVersion` (aka `firmawareVersion`) parameter to the step. Without it, uploaded images get the (default?) version called `Version 2` in the UI. Now you can set it to your desired image version.
- When choosing not to wait for status/result (for a much faster CI pipeline) - step would always fail, as plugin would still try to get the report and check for thresholds, which is pointless (as it receives the "image not ready error"). Also it would still continue to `waitForEndStatus` which I believe is also not needed in this case. Added a conditions to prevent that.
- There was a collision in the Jenkins artifacts (scan reports) directory when using the step multiple times in one job (like the common use case of uploading multiple images using parallel steps). On of the steps would always fail with the "Couldn't create artifact directory. Artifacts wont be saved." error. Now dir name uses the image name instead the queue id number to prevent that from happening.
- Removed redundant import, unused class attributes
- Handled potential memory leak when opening Scanner and not closing it 
- Handled serialization errors for the listener in ScannerAction - removed it from being a class attribute. This also seem to have prevented the job threads from closing up properly, so after jenkins restart it tried to resume finished jobs and marked them as failed
